### PR TITLE
增加一次性发送字符串的函数指针，以及对应的宏定义

### DIFF
--- a/API_Reference.md
+++ b/API_Reference.md
@@ -9,6 +9,18 @@
 - **`CMD_SEND_CHAR(c)`**
   - **Purpose**: Used to send a character to the user.
   - **Description**: By default, it uses `TinyCmd_SendChar(c)` to send characters. If you need to use a custom `putchar` function, you can redefine this macro.
+
+- **`USE_USART_DMA_SEND_STR`**
+  - **Purpose**: Used to enable or disable the use of USART DMA.
+  - **Description**: If defined, it enables the use of USART DMA for sending strings. If not defined, it disables the use of USART DMA.
+
+- **`CMD_SEND_STRING(str)`**
+  - **Purpose**: Used to send a string to the user.
+  - **Description**: If `USE USART DMA SEND STR` is defined, the string will be sent using `TinyCmd SendString(str)`. If 'USE USART DMA SEND STR' is not defined,  will use `CMD_SEND_CHAR(c)` sends characters.
+  - **Note**:
+    - If `USE USART DMA SEND STR` is defined, it is necessary to ensure that the `TinyCmd SendString(str)` function is implemented correctly and is consistent with the definition of the `CMD SEND STRING(str)` macro.
+    - This function is used to enhance the performance of serial port transmission, especially when using USART+DMA.
+
 - **`CMD_RPT_BUF_SIZE`**
   - **Purpose**: The size of the report buffer, used to store data to be sent.
   - **Default Value**: 255
@@ -41,6 +53,10 @@
 - **`SendCharFunc`**
   - **Purpose**: Function pointer type for sending characters.
   - **Definition**: `typedef void (*SendCharFunc)(char c);`
+
+- **`SendStringFunc`**
+  - **Purpose**: Function pointer type for sending strings.
+  - **Definition**: `typedef void (*SendStringFunc)(const char* str);`
 
 #### Enumerations
 
@@ -113,7 +129,7 @@
 
 #### Functions
 
-- **`char\* TinyCmd_strcpy(char\* dest, const char\* src)`**
+- **`char* TinyCmd_strcpy(char* dest, const char* src)`**
 
   - **Purpose**: Copies a string.
 
@@ -139,7 +155,7 @@
     - `TINYCMD_SUCCESS`: Processing successful.
     - `TINYCMD_FAILED`: Processing failed.
 
-- **`TinyCmd_Status TinyCmd_Add_Cmd(TinyCmd_Command\* newCmd)`**
+- **`TinyCmd_Status TinyCmd_Add_Cmd(TinyCmd_Command* newCmd)`**
 
   - **Purpose**: Adds a new command to the list of recognizable and executable commands.
 
@@ -156,7 +172,7 @@
     - `TINYCMD_SUCCESS`: Addition successful.
     - `TINYCMD_FAILED`: Addition failed.
 
-- **`TinyCmd_Status TinyCmd_Arg_Check(const char\* arg1, TinyCmd_Counter_Type p_arg2)`**
+- **`TinyCmd_Status TinyCmd_Arg_Check(const char* arg1, TinyCmd_Counter_Type p_arg2)`**
 
   - **Purpose**: Checks an argument.
 
@@ -186,7 +202,7 @@
 
   - **Return Value**: Length of the argument.
 
-- **`TinyCmd_Status TinyCmd_Arg_To_Num(TinyCmd_Counter_Type p_arg, void\* out_val, TinyCmd_NumType type)`**
+- **`TinyCmd_Status TinyCmd_Arg_To_Num(TinyCmd_Counter_Type p_arg, void* out_val, TinyCmd_NumType type)`**
 
   - **Purpose**: Converts an argument to a specified numeric type.
 
@@ -205,7 +221,7 @@
     - `TINYCMD_SUCCESS`: Conversion successful.
     - `TINYCMD_FAILED`: Conversion failed.
 
-- **`TinyCmd_Status TinyCmd_Report(const char\* format, ...)`**
+- **`TinyCmd_Status TinyCmd_Report(const char* format, ...)`**
 
   - **Purpose**: Reports information.
 

--- a/API_Reference_ZH.md
+++ b/API_Reference_ZH.md
@@ -11,6 +11,18 @@
 - **`CMD_SEND_CHAR(c)`**
   - **用途**：用于发送字符到用户。
   - **描述**：默认使用 `TinyCmd_SendChar(c)` 发送字符。如果需要使用自定义的 `putchar` 函数，可以重新定义此宏。
+
+- **`USE_USART_DMA_SEND_STR`**
+  - **用途**：与`CMD_SEND_STRING(str)`搭配使用，用于启用或禁用 USART DMA 发送字符串。
+  - **描述**：如果定义了此宏，将启用 USART DMA 发送字符串。如果未定义，将禁用 USART DMA 发送字符串。
+
+- **`CMD_SEND_STRING(str)`**
+  - **用途**：用于发送字符串到用户。
+  - **描述**：如果 `USE_USART_DMA_SEND_STR` 定义了，将使用 `TinyCmd_SendString(str)` 发送字符串。 如果未定义 `USE_USART_DMA_SEND_STR`，将使用 `CMD_SEND_CHAR(c)` 发送字符。
+  - **注意**：
+    - 如果定义了 `USE_USART_DMA_SEND_STR`，则需要确保 `TinyCmd_SendString(str)` 函数已正确实现，并且与 `CMD_SEND_STRING(str)` 宏的定义一致。
+    - 这个函数用于提高串口发送的性能，尤其是在使用USART+DMA时。
+
 - **`CMD_RPT_BUF_SIZE`**
   - **用途**：报告缓冲区的大小，用于存储待发送的数据
   - **默认值**：255
@@ -43,6 +55,10 @@
 - **`SendCharFunc`**
   - **用途**：发送字符的函数指针类型。
   - **定义**：`typedef void (*SendCharFunc)(char c);`
+
+- **`SendStringFunc`**
+  - **用途**：发送字符串的函数指针类型。
+  - **定义**：`typedef void (*SendStringFunc)(const char* str);`
 
 #### 枚举
 

--- a/TinyCmd.c
+++ b/TinyCmd.c
@@ -428,6 +428,13 @@ TinyCmd_Status TinyCmd_Handler(void) {
         token = TinyCmd_strtok_s(NULL, delims ,&context);
     }
 
+    TinyCmd_Report("Command: %s\n", command);
+    TinyCmd_Report("Number of args: %d\n", i);
+    for (TinyCmd_Counter_Type j = 0; j < i; j++)
+    {
+        TinyCmd_Report("Arg[%d]: %s\n", j, TinyCmd_buf.arg[j]);
+    }
+    
     //Excute callback function of command
     for (i = 0; i < TinyCmdRunning_Cmd.length; i++) {
 

--- a/TinyCmd.c
+++ b/TinyCmd.c
@@ -359,9 +359,14 @@ static void dtoa(double value, char* buffer, int precision) {
 //TinyCmd_Status TinyCmd_SendChar(char c)
 //Description:Send a character to some where user designated.
 static void send_string(const char* str) {
-    while (*str) {
+#ifndef USE_USART_DMA_SEND_STR
+    while (*str)
+    {
         CMD_SEND_CHAR(*str++);
     }
+#else
+    CMD_SEND_STRING(str);
+#endif
 }
 
 //TinyCmd_Status TinyCmd_trim(char *str)

--- a/TinyCmd.h
+++ b/TinyCmd.h
@@ -32,10 +32,20 @@ extern "C" {
 #endif
 
 //This macro is used to send a character to the user
-//If you have a "putchar" function but it has different type from 
+//If you have a "putchar" function but it has different type from
 //"typedef void (*SendCharFunc)(char c);" such as "int (*SendCharFunc)(char c)"
 //You can redefine this function by you "putchar" function to prevent the warrings.
 #define CMD_SEND_CHAR(c) TinyCmd_SendChar(c)
+
+// This macro is used to enable USART send by DMA
+// If you want to use TinyCmd_SendString(str), you must enable this macro
+// #define USE_USART_DMA_SEND_STR
+
+//This macro is used to send a string to the user
+//If you want to send data using DMA + USART, implementing a TinyCmd SendChar(c) is a huge waste of performance.
+//TinyCmd SendChar(c) function can only send one character at a time.
+//Implementing a function that continuously sends strings is a better choice
+#define CMD_SEND_STRING(str) TinyCmd_SendString(str)
 
 //Constant for configure TinyCmd****************************************************************//
 
@@ -69,6 +79,10 @@ typedef unsigned char TinyCmd_Counter_Type;
 //description: This function is used to send a character to the user,=
 typedef void (*SendCharFunc)(char c);
 
+// SendStringFunc type for TinyCmd
+// description: This function is used to send string to the user,
+typedef void (*SendStringFunc)(const char *str);
+
 //Global structs****************************************************************************//
 
 //TinyCmd input buffer struct:
@@ -88,7 +102,7 @@ typedef struct TinyCmd_inuput{
 //callback: The callback function pointer
 typedef struct TinyCmd_Command{
 	const char* command;
-	TinyCmd_CallBack_Ret (*callback)(void);	
+	TinyCmd_CallBack_Ret (*callback)(void);
 }TinyCmd_Command;
 
 //Global enums****************************************************************************//


### PR DESCRIPTION
我觉得底层的send_char一次只发一个字符太慢了，尤其是用了DMA的时候。对于串口+DMA的情况，频繁的触发DMA也不是什么好事。所以我加了两个宏，简单的支持了使用DMA直接发送一个字符串的功能。但是并不完善，我觉得TinyCmd_report可以优化一下，主要思路就是用vsnprintf()函数，就像下面这样
```c
/**
 * @brief 串口发送格式化字符串，该函数已过时，现在由TinyCmd_Report()函数替代
 * @param huart 指向UART_HandleTypeDef的指针
 * @param format 格式化字符串
 * @return 发送的字节数
 */
int Usart_Printf(UART_HandleTypeDef *huart, const char *format, ...)
{
  osSemaphoreAcquire(tx_end_BinarySemHandle, osWaitForever);

  va_list args;
  va_start(args, format);
  tx_len = vsnprintf((char *)tx_buffer, sizeof(tx_buffer), format, args);
  va_end(args);

  if (tx_len >= sizeof(tx_buffer))
  {
    return -1; // 错误处理
  }

  DMA_Usart_Send(huart, tx_buffer, tx_len);
  return tx_len;
}
```
如果按照这个思路，要动的东西就比较多了。格式化的任务完全交给了vsnprintf()来完成，直接在tx_buffer里面取格式化后的字符串，不论是一个一个字符发送还是用DMA直接发送都简单了。但是你写的哪些itoa dtoa啥的都用不上了，要删很多东西，这毕竟是你的库。
你后面要是打算继续优化，可以参考以下这个思路。